### PR TITLE
Fix typo in footer

### DIFF
--- a/frontend_angular/src/app/footer/footer.component.html
+++ b/frontend_angular/src/app/footer/footer.component.html
@@ -20,8 +20,7 @@
       </div>
       <div class="column is-half">
         <h5 class="title is-5" i18n="@@about">À propos</h5>
-        <p>
-          i18n="about | tell the history of the application"> Cette plateforme
+        <p i18n="about | tell the history of the application"> Cette plateforme
           (adh6) est la 6ème version des plateformes de gestion d'adhérents de
           MiNET dont le développement a commencé à partir de 2016 pour remplacer
           adh5 (2011). <br />


### PR DESCRIPTION
i18n was outside of the p tag

![poor i18n left outside](https://github.com/user-attachments/assets/17c6c06f-87a7-4c30-9681-90f2d228379b)
